### PR TITLE
A simple source map with mangled identifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 | --- | --- |
 | [increment](./examples/increment) | a simple source map example |
 | [source mapped js.min files](http://wbamberg.github.io/example-websites/source-mapping/index.html) | simple webpack example|
+| [mangled names](./examples/sequence-print/sequence-print.html) | a simple source map with mangled identifiers|
 
 ### Local Test Pages
 

--- a/examples/sequence-print/sequence_print.html
+++ b/examples/sequence-print/sequence_print.html
@@ -1,0 +1,6 @@
+<script src="sequence_print.min.js"></script>
+
+Result = <span id="res"></span>
+<script>
+   document.getElementById("res").textContent = sequencePrint(3, 10);
+</script>

--- a/examples/sequence-print/sequence_print.js
+++ b/examples/sequence-print/sequence_print.js
@@ -1,0 +1,7 @@
+function sequencePrint(from, to) {
+  var buffer = [];
+  for (var current = from; current <= to; current++) {
+    buffer.push(current);
+  }
+  return buffer.join(',');
+}

--- a/examples/sequence-print/sequence_print.min.js
+++ b/examples/sequence-print/sequence_print.min.js
@@ -1,0 +1,2 @@
+function sequencePrint(n,r){for(var e=[],u=n;u<=r;u++)e.push(u);return e.join(",")}
+//# sourceMappingURL=sequence_print.min.js.map

--- a/examples/sequence-print/sequence_print.min.js.map
+++ b/examples/sequence-print/sequence_print.min.js.map
@@ -1,0 +1,1 @@
+{"version":3,"sources":["sequence_print.js"],"names":["sequencePrint","from","to","buffer","current","push","join"],"mappings":"AAAA,SAASA,cAAcC,EAAMC,GAE3B,IAAK,IADDC,KACKC,EAAUH,EAAMG,GAAWF,EAAIE,IACtCD,EAAOE,KAAKD,GAEd,OAAOD,EAAOG,KAAK"}


### PR DESCRIPTION
A source map can contain names, which can be displayed by the devtools (see e.g. Chrome locals support)