### PR TITLE
Fixes 52 - change protocol to https for worker examples

### DIFF
--- a/examples/workers/big-data.html
+++ b/examples/workers/big-data.html
@@ -169,7 +169,7 @@ window.addEventListener(
 </script>
 
 <!--[if IE]>
-<script src="http://ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/chrome-frame/1/CFInstall.min.js"></script>
 <script>CFInstall.check({mode: 'overlay'});</script>
 <![endif]-->
 </body>

--- a/examples/workers/high-prime.html
+++ b/examples/workers/high-prime.html
@@ -3,7 +3,7 @@
  <head>
    <title>Web Worker: The highest prime number</title>
    <!-- Get the latest jQuery code -->
-   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
    <meta charset=utf-8 />
  </head>
  <style>

--- a/examples/workers/inline.html
+++ b/examples/workers/inline.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <title>Web Worker: Inline worker example</title>
     <meta name="author" content="Ido Green">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
   </head>
 
   <style>

--- a/examples/workers/pi.html
+++ b/examples/workers/pi.html
@@ -3,7 +3,7 @@
  <head>
    <title>Web Worker: The Run After Pi</title>
    <!-- Get the latest jQuery code -->
-   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
    <meta charset=utf-8 />
  </head>
  <style>

--- a/examples/workers/shared-tweets-b.html
+++ b/examples/workers/shared-tweets-b.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Shared Web Workers: Twitter Example</title>
     <meta name="author" content="Ido Green">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
     <style>
       #result {
         background: orange;

--- a/examples/workers/shared-tweets.html
+++ b/examples/workers/shared-tweets.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Shared Web Workers: Twitter Example</title>
     <meta name="author" content="Ido Green">
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
     <style>
       #result {
         background: lightblue;


### PR DESCRIPTION
Fixes: #52 

Changed all CDN to load over https, for worker examples

There was option to change urls to //ajax.googleapis.com, so that it follows the page protocol. But it will fail if the html is loaded over file://