### PR TITLE
Fix breakpoints example

### DIFF
--- a/examples/breakpoints.html
+++ b/examples/breakpoints.html
@@ -4,7 +4,7 @@
   </head>
 
   <body>
-    <script src="/column-breakpoints.js"></script>
+    <script src="column-breakpoints.js"></script>
   </body>
 
   <button onclick="ternary()">ternary</button>


### PR DESCRIPTION
Loading the example script from /column-breakpoints.js works when
running the example project on a local clone but does not work when
accessed at https://firefox-dev.tools/debugger-examples/examples/breakpoints.html
where https://firefox-dev.tools/column-breakpoints.js results in 404.